### PR TITLE
Csv escape

### DIFF
--- a/formats/csv.js
+++ b/formats/csv.js
@@ -7,6 +7,10 @@ module.exports.is = function isCSV( sample, options ) {
         sample.toString().split( "\n" )[ 0 ].indexOf( DEFAULT_DELIMITER ) != -1;
 }
 
+module.exports.isOneColumn = function isCSV( sample ) {
+    return sample.toString().indexOf( "\n" ) != -1;
+}
+
 module.exports.parser = function ( options ) {
     var useDelimiter = options.delimiter || DEFAULT_DELIMITER;
     var csvparse = require( "csv-parse" );

--- a/formats/csv.js
+++ b/formats/csv.js
@@ -12,7 +12,7 @@ module.exports.parser = function ( options ) {
     var csvparse = require( "csv-parse" );
     return csvparse({
         skip_empty_lines: true,
-        escape: options.escape || '"',
+        escape: options.escape || '\\',
         columns: options.columns || true,
         relax: true,
         delimiter: useDelimiter

--- a/formats/csv.js
+++ b/formats/csv.js
@@ -12,7 +12,7 @@ module.exports.parser = function ( options ) {
     var csvparse = require( "csv-parse" );
     return csvparse({
         skip_empty_lines: true,
-        escape: "\\",
+        escape: options.escape || '"',
         columns: options.columns || true,
         relax: true,
         delimiter: useDelimiter

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ structurize.guess = function ( sample, options ) {
     // new lines to be considered as csv (only if no other option is valid).
     // Also, we can't move the csv test to the end since the list must be
     // ordered by relevancy/statistics
-    if (sample.toString().indexOf("\n") >= 0)
+    // since this is not a new format and since this test should always be last
+    // it is best to place it here and not create a new format
+    if (csvModule.isOneColumn(sample))
         return csvModule.type
 }
 

--- a/index.js
+++ b/index.js
@@ -9,12 +9,14 @@ function structurize ( options ) {
     return new Stream( options );
 }
 
+var csvModule = require( "./formats/csv" )
+
 structurize.formats = [
     require( "./formats/xlsx" ),
     require( "./formats/tar" ),
     require( "./formats/gzip" ),
     require( "./formats/json" ),
-    require( "./formats/csv" ),
+    csvModule,
     require( "./formats/tsv" ),
     require( "./formats/querystring" ),
     require( "./formats/wdl" ),
@@ -27,6 +29,14 @@ structurize.guess = function ( sample, options ) {
             return this.formats[ i ].type;
         }
     }
+    // if no format is suitable and sample has new lines,
+    // consider it as a csv with 1 column
+    // this check must be the last check since we don't want every sample with
+    // new lines to be considered as csv (only if no other option is valid).
+    // Also, we can't move the csv test to the end since the list must be
+    // ordered by relevancy/statistics
+    if (sample.toString().indexOf("\n") >= 0)
+        return csvModule.type
 }
 
 structurize.parser = function ( type, options ) {


### PR DESCRIPTION
This change deals with 2 things:
1. If sample format can't be guessed but includes new lines, consider it as a CSV with 1 column
2. provide the ability to change the CSV escape character in order to support valid CSV's which are escaped with a quote (") and not with a double backslash (\\). The default behavior was still untouched so old sources wouldn't be effected
---
[Asana - CSV with 1 column](https://app.asana.com/0/327352447154397/145676052219288)
[Asana - CSV escape characters](https://app.asana.com/0/327352447154397/342687560606945)